### PR TITLE
feat: speak-hooks で Notification hook と last_assistant_message に対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run build       # TypeScript compile → dist/
+npm run dev -- <args>  # Run via tsx without building (e.g. npm run dev -- speak "テスト")
+```
+
+No test runner is configured. Manual testing requires a running VoiceVox engine on localhost:50021.
+
+After editing, rebuild with `npm run build` and verify with `voicevox-cli test`.
+
+## Architecture
+
+**Entry point:** `src/index.ts` — registers all commander subcommands, resolves config via `resolveConfig()`, then delegates to command modules.
+
+**Command modules** (`src/commands/`): each exports a `run*` function. Commands output JSON to stdout and call `process.exit(1)` on error.
+
+**VoiceVox client** (`src/voicevox/client.ts`): wraps the HTTP API. The `speak()` method calls `/audio_query` then `/synthesis`, writes a temp WAV, plays it with `afplay` (macOS only), then deletes the file.
+
+**Config resolution** (`src/config.ts`): priority order for `speaker` and `speed` is CLI flag > `VOICEVOX_SPEAKER`/`VOICEVOX_SPEED` env vars > `~/.config/voicevox-cli/config.json` > defaults (speaker=1, speed=1.3). The speakers cache (`~/.config/voicevox-cli/speakers-cache.json`) has a 24h TTL and is used by `current-speaker` for name resolution without hitting the API.
+
+**speak-hooks** (`src/commands/speak-hooks.ts`): designed for Claude Code Stop/SubagentStop/Notification hooks. Reads JSON from stdin (skips if TTY). Text priority: `last_assistant_message` field → parse JSONL transcript at `transcript_path` → `--fallback` text. Exits immediately if `stop_hook_active` is true (prevents infinite loops).
+
+**MCP server** (`src/commands/mcp-server.ts`): stdio MCP server exposing `voicevox_test`, `voicevox_speak`, `voicevox_speakers` tools.
+
+## Module system
+
+ESM with `"type": "module"` and `moduleResolution: NodeNext`. All internal imports must use `.js` extensions (e.g. `import { foo } from "./bar.js"`).

--- a/src/commands/speak-hooks.ts
+++ b/src/commands/speak-hooks.ts
@@ -3,8 +3,13 @@ import { runSpeak } from "./speak.js";
 import { resolveConfig } from "../config.js";
 
 interface HookInput {
+  hook_event_name?: string;
   stop_hook_active?: boolean;
   transcript_path?: string;
+  last_assistant_message?: string;
+  // Notification hook fields
+  message?: string;
+  notification_type?: string;
 }
 
 interface TranscriptEntry {
@@ -14,7 +19,6 @@ interface TranscriptEntry {
     content: string | Array<{ type: string; text?: string }>;
   };
 }
-
 
 function readStdin(): Promise<string> {
   // TTY から直接実行された場合はハングを防ぐため空 JSON を即時返す
@@ -27,6 +31,33 @@ function readStdin(): Promise<string> {
     process.stdin.on("data", (chunk) => { data += chunk; });
     process.stdin.on("end", () => { resolve(data); });
   });
+}
+
+async function extractFromTranscript(transcriptPath: string, chars: number): Promise<string | null> {
+  try {
+    const raw = await readFile(transcriptPath, "utf-8");
+    const entries = raw
+      .split("\n")
+      .filter((line) => line.trim())
+      .map((line) => { try { return JSON.parse(line) as TranscriptEntry; } catch { return null; } })
+      .filter((e): e is TranscriptEntry => e !== null && e.type === "assistant" && e.message != null);
+    if (entries.length > 0) {
+      const last = entries[entries.length - 1];
+      let content = last.message!.content;
+      if (Array.isArray(content)) {
+        content = content
+          .filter((c) => c.type === "text")
+          .map((c) => c.text ?? "")
+          .join(" ");
+      }
+      if (typeof content === "string" && content.trim()) {
+        return content.slice(0, chars);
+      }
+    }
+  } catch {
+    // transcript が読めない場合は null を返す
+  }
+  return null;
 }
 
 export async function runSpeakHooks(options: {
@@ -57,33 +88,21 @@ export async function runSpeakHooks(options: {
   });
 
   const chars = Number.isFinite(options.chars) && options.chars > 0 ? options.chars : 100;
+  const eventName = hookData.hook_event_name;
   let text = options.fallback;
 
-  if (hookData.transcript_path) {
-    try {
-      const raw = await readFile(hookData.transcript_path, "utf-8");
-      // Claude Code のトランスクリプトは JSONL 形式（1行1JSON）
-      // 各行は { type: "assistant", message: { role, content } } の構造
-      const entries = raw
-        .split("\n")
-        .filter((line) => line.trim())
-        .map((line) => { try { return JSON.parse(line) as TranscriptEntry; } catch { return null; } })
-        .filter((e): e is TranscriptEntry => e !== null && e.type === "assistant" && e.message != null);
-      if (entries.length > 0) {
-        const last = entries[entries.length - 1];
-        let content = last.message!.content;
-        if (Array.isArray(content)) {
-          content = content
-            .filter((c) => c.type === "text")
-            .map((c) => c.text ?? "")
-            .join(" ");
-        }
-        if (typeof content === "string" && content.trim()) {
-          text = content.slice(0, chars);
-        }
-      }
-    } catch {
-      // transcript が読めない場合はフォールバックメッセージを使用
+  if (eventName === "Notification") {
+    // Notification hook: message フィールドを直接使用
+    if (hookData.message?.trim()) {
+      text = hookData.message.slice(0, chars);
+    }
+  } else {
+    // Stop / SubagentStop: last_assistant_message を優先、なければ transcript を解析
+    if (hookData.last_assistant_message?.trim()) {
+      text = hookData.last_assistant_message.slice(0, chars);
+    } else if (hookData.transcript_path) {
+      const extracted = await extractFromTranscript(hookData.transcript_path, chars);
+      if (extracted) text = extracted;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ program
 
 program
   .command("speak-hooks")
-  .description("Stop hook 用: stdin の hook JSON を解析して最後の assistant メッセージを読み上げます")
+  .description("Stop/SubagentStop/Notification hook 用: stdin の hook JSON を解析して読み上げます")
   .option("--host <host>", "VoiceVoxホスト", DEFAULT_HOST)
   .option("--port <port>", "VoiceVoxポート", String(DEFAULT_PORT))
   .option("-s, --speaker <id>", "話者ID")


### PR DESCRIPTION
## Summary

- `hook_event_name` によるイベント種別の振り分けを追加
  - `Notification`: `message` フィールドを直接読み上げ
  - `Stop` / `SubagentStop`: `last_assistant_message` を優先し、なければ `transcript_path` のJSONLを解析
- transcript解析ロジックを `extractFromTranscript()` として分離
- `CLAUDE.md` にプロジェクト構成ドキュメントを追加

## Test plan

- [ ] Stop hook で最後のアシスタントメッセージが読み上げられること
- [ ] Notification hook で通知メッセージが読み上げられること
- [ ] `stop_hook_active: true` のときスキップされること
- [ ] TTY から直接実行してもハングしないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)