### PR TITLE
feat: Stop/SubagentStop フックの読み上げに「セッション終了: 」プレフィックスを追加

### DIFF
--- a/src/commands/speak-hooks.ts
+++ b/src/commands/speak-hooks.ts
@@ -121,6 +121,7 @@ export async function runSpeakHooks(options: {
       const extracted = await extractFromTranscript(hookData.transcript_path);
       if (extracted) text = extracted;
     }
+    text = "セッション終了: " + text;
   }
 
   await runSpeak(transformUrls(text), options.host, options.port, speaker, speed);


### PR DESCRIPTION
## Summary

- Stop / SubagentStop フックで読み上げるテキストの先頭に「セッション終了: 」を付加
- Notification フックや Codex 通知には影響なし

## Test plan

- [ ] Claude Code の Stop フック経由で `voicevox-cli speak-hooks` を実行し、「セッション終了: 〇〇」と読み上げられることを確認
- [ ] Notification フックでは prefix が付かないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)