### PR TITLE
feat: status_line絵文字を🎙️に変更・configから設定可能に、stop hookメッセージを更新

### DIFF
--- a/src/commands/current-speaker.test.ts
+++ b/src/commands/current-speaker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { resolveSpeakerName } from "./current-speaker.js";
+import { resolveSpeakerName, runCurrentSpeaker } from "./current-speaker.js";
 import * as config from "../config.js";
 
 // Mock dependencies - use importActual to preserve other exports
@@ -9,6 +9,7 @@ vi.mock("../config.js", async () => {
     ...actual,
     readSpeakersCache: vi.fn(),
     writeSpeakersCache: vi.fn(),
+    resolveConfig: vi.fn(),
   };
 });
 
@@ -17,6 +18,16 @@ vi.mock("../voicevox/client.js", () => ({
 }));
 
 const mockReadSpeakersCache = vi.mocked(config.readSpeakersCache);
+const mockResolveConfig = vi.mocked(config.resolveConfig);
+
+const BASE_RESOLVED_CONFIG = {
+  speaker: 1,
+  speed: 1.3,
+  timeoutMs: 30000,
+  retryCount: 0,
+  retryDelayMs: 1000,
+  statusLineEmoji: undefined,
+};
 
 describe("resolveSpeakerName", () => {
   beforeEach(() => {
@@ -61,5 +72,48 @@ describe("resolveSpeakerName", () => {
 
     const name = await resolveSpeakerName(1, "localhost", 50021);
     expect(name).toBeUndefined();
+  });
+});
+
+describe("runCurrentSpeaker", () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.clearAllMocks();
+    mockReadSpeakersCache.mockResolvedValue({
+      timestamp: Date.now(),
+      speakers: [{ id: 1, name: "四国めたん（ノーマル）" }],
+    });
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it("uses default emoji when statusLineEmoji is not configured", async () => {
+    mockResolveConfig.mockResolvedValueOnce({ ...BASE_RESOLVED_CONFIG, statusLineEmoji: undefined });
+
+    await runCurrentSpeaker({ host: "localhost", port: 50021, json: false });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith("🎙️ VOICEVOX:四国めたん（ノーマル）");
+  });
+
+  it("uses custom emoji from config", async () => {
+    mockResolveConfig.mockResolvedValueOnce({ ...BASE_RESOLVED_CONFIG, statusLineEmoji: "🔔" });
+
+    await runCurrentSpeaker({ host: "localhost", port: 50021, json: false });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith("🔔 VOICEVOX:四国めたん（ノーマル）");
+  });
+
+  it("outputs JSON without emoji when --json flag is set", async () => {
+    mockResolveConfig.mockResolvedValueOnce({ ...BASE_RESOLVED_CONFIG });
+
+    await runCurrentSpeaker({ host: "localhost", port: 50021, json: true });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      JSON.stringify({ status: "ok", speaker: 1, name: "四国めたん（ノーマル）" })
+    );
   });
 });

--- a/src/commands/current-speaker.ts
+++ b/src/commands/current-speaker.ts
@@ -1,7 +1,7 @@
-import { resolveConfig, readSpeakersCache, writeSpeakersCache, readConfig } from "../config.js";
+import { resolveConfig, readSpeakersCache, writeSpeakersCache } from "../config.js";
+import { VoiceVoxClient } from "../voicevox/client.js";
 
 const DEFAULT_STATUS_LINE_EMOJI = "🎙️";
-import { VoiceVoxClient } from "../voicevox/client.js";
 
 export async function resolveSpeakerName(
   speakerId: number,
@@ -33,14 +33,14 @@ export async function runCurrentSpeaker(options: {
   port: number;
   json: boolean;
 }): Promise<void> {
-  const [{ speaker }, config] = await Promise.all([resolveConfig({}), readConfig()]);
+  const { speaker, statusLineEmoji } = await resolveConfig({});
   const name = await resolveSpeakerName(speaker, options.host, options.port);
   const label = name ?? `Speaker ${speaker}`;
 
   if (options.json) {
     console.log(JSON.stringify({ status: "ok", speaker, name: label }));
   } else {
-    const emoji = config.statusLineEmoji ?? DEFAULT_STATUS_LINE_EMOJI;
+    const emoji = statusLineEmoji ?? DEFAULT_STATUS_LINE_EMOJI;
     console.log(`${emoji} VOICEVOX:${label}`);
   }
 }

--- a/src/commands/speak-hooks.ts
+++ b/src/commands/speak-hooks.ts
@@ -1,4 +1,4 @@
-import { readFile, appendFile, mkdir } from "fs/promises";
+import { appendFile, mkdir } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import { runSpeak } from "./speak.js";
@@ -18,13 +18,6 @@ interface HookInput {
   notification_type?: string;
 }
 
-interface TranscriptEntry {
-  type: string;
-  message?: {
-    role: string;
-    content: string | Array<{ type: string; text?: string }>;
-  };
-}
 
 function readStdin(): Promise<string> {
   // TTY から直接実行された場合はハングを防ぐため空 JSON を即時返す
@@ -86,32 +79,6 @@ export function transformUrls(text: string): string {
   return text.replace(/https?:\/\/([^/\s]+)[^\s]*/g, "URL: $1");
 }
 
-async function extractFromTranscript(transcriptPath: string): Promise<string | null> {
-  try {
-    const raw = await readFile(transcriptPath, "utf-8");
-    const entries = raw
-      .split("\n")
-      .filter((line) => line.trim())
-      .map((line) => { try { return JSON.parse(line) as TranscriptEntry; } catch { return null; } })
-      .filter((e): e is TranscriptEntry => e !== null && e.type === "assistant" && e.message != null);
-    if (entries.length > 0) {
-      const last = entries[entries.length - 1];
-      let content = last.message!.content;
-      if (Array.isArray(content)) {
-        content = content
-          .filter((c) => c.type === "text")
-          .map((c) => c.text ?? "")
-          .join("\n");
-      }
-      if (typeof content === "string" && content.trim()) {
-        return firstLine(content);
-      }
-    }
-  } catch {
-    // transcript が読めない場合は null を返す
-  }
-  return null;
-}
 
 export async function runSpeakHooks(options: {
   host: string;
@@ -165,13 +132,7 @@ export async function runSpeakHooks(options: {
       text = firstLine(codexMessage);
     }
   } else {
-    // Stop / SubagentStop: last_assistant_message を優先、なければ transcript を解析
-    if (hookData.last_assistant_message?.trim()) {
-      text = firstLine(hookData.last_assistant_message);
-    } else if (hookData.transcript_path) {
-      const extracted = await extractFromTranscript(hookData.transcript_path);
-      if (extracted) text = extracted;
-    }
+    // Stop / SubagentStop: 固定文を読み上げる
     text = "タスクが完了しました。";
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,6 +97,7 @@ export async function resolveConfig(options: {
   timeoutMs: number;
   retryCount: number;
   retryDelayMs: number;
+  statusLineEmoji: string | undefined;
 }> {
   const file = await readConfig();
 
@@ -144,5 +145,5 @@ export async function resolveConfig(options: {
     DEFAULT_RETRY_DELAY_MS
   );
 
-  return { speaker, speed, timeoutMs, retryCount, retryDelayMs };
+  return { speaker, speed, timeoutMs, retryCount, retryDelayMs, statusLineEmoji: file.statusLineEmoji };
 }

--- a/src/voicevox/types.ts
+++ b/src/voicevox/types.ts
@@ -76,6 +76,13 @@ export interface Config {
   timeoutMs?: number;
   retryCount?: number;
   retryDelayMs?: number;
+  /**
+   * Emoji (or text) shown as a prefix in the status line output of `voicevox current-speaker`.
+   *
+   * Note: This option is intended to be configured by manually editing the
+   * config file and is not currently supported by the `voicevox config set`
+   * CLI command.
+   */
   statusLineEmoji?: string;
 }
 


### PR DESCRIPTION
## Summary

- `current-speaker`コマンドのステータスライン絵文字を `💬` から `🎙️` に変更
- `Config`に`statusLineEmoji`フィールドを追加し、`~/.config/voicevox-cli/config.json`から絵文字を差し替え可能に（デフォルト: `🎙️`）
- stop hook時の読み上げメッセージを「セッション終了: ...」から固定文「タスクが完了しました。」に変更

## Changes

### `src/voicevox/types.ts`
- `Config`インターフェースに`statusLineEmoji?: string`を追加

### `src/commands/current-speaker.ts`
- デフォルト絵文字を`🎙️`に変更
- `readConfig()`でconfigを読み込み、`statusLineEmoji`が設定されていればそちらを使用

### `src/commands/speak-hooks.ts`
- stop/subagentStop hookのメッセージプレフィックスを「セッション終了: 」から「タスクが完了しました。」に変更

## Configuration example

```json
{
  "statusLineEmoji": "🔔"
}
```

## Test plan

- [ ] `voicevox current-speaker`でステータスラインに`🎙️`が表示されること
- [ ] `config.json`に`statusLineEmoji`を設定すると差し替わること
- [ ] stop hookが実行された際に「タスクが完了しました。」が読み上げられること
- [ ] `npm run build`が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)