### PR TITLE
fix: align setup-hooks events with Claude Code v2.1.86 validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.12.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -2542,9 +2542,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -2566,9 +2566,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/skills/voicevox-cli/references/hooks-setup.md
+++ b/skills/voicevox-cli/references/hooks-setup.md
@@ -14,7 +14,7 @@ voicevox-cli setup-hooks --scope project
 # ユーザースコープ (全プロジェクト共通)
 voicevox-cli setup-hooks --scope user
 
-# 全17イベントを設定
+# 全13イベントを設定
 voicevox-cli setup-hooks --all
 
 # 特定のイベントのみ
@@ -24,7 +24,7 @@ voicevox-cli setup-hooks --events Stop,Notification,SessionStart
 voicevox-cli setup-hooks --dry-run
 ```
 
-## 対応イベント
+## 対応イベント (Claude Code v2.1.86 settings.json バリデーション準拠)
 
 | イベント | 説明 |
 |---------|------|
@@ -33,18 +33,14 @@ voicevox-cli setup-hooks --dry-run
 | `UserPromptSubmit` | ユーザープロンプト送信 |
 | `PreToolUse` | ツール実行前 |
 | `PostToolUse` | ツール実行後 |
-| `PostToolUseFailure` | ツール実行失敗 |
 | `Notification` | 通知 |
-| `SubagentStart` | サブエージェント開始 |
 | `SubagentStop` | サブエージェント終了 |
 | `Stop` | タスク完了 |
-| `TeammateIdle` | チームメイトアイドル |
-| `TaskCompleted` | タスク完了 |
-| `ConfigChange` | 設定変更 |
-| `WorktreeCreate` | Worktree 作成 |
-| `WorktreeRemove` | Worktree 削除 |
 | `PreCompact` | コンパクト前 |
-| `PermissionRequest` | 権限リクエスト |
+| `PostCompact` | コンパクト後 |
+| `TeammateIdle` | チームメイトアイドル |
+| `TaskCreated` | タスク作成 |
+| `TaskCompleted` | タスク完了 |
 
 ## speak-hooks の動作
 

--- a/src/commands/speak-hooks.test.ts
+++ b/src/commands/speak-hooks.test.ts
@@ -341,69 +341,6 @@ describe("runSpeakHooks", () => {
     });
   });
 
-  describe("PermissionRequest", () => {
-    it("speaks permission request with tool name", async () => {
-      const { runSpeak } = await import("./speak.js");
-      const payload = JSON.stringify({
-        hook_event_name: "PermissionRequest",
-        requested_tool: "Bash",
-      });
-      await runSpeakHooks({ ...baseOptions, payload });
-      expect(runSpeak).toHaveBeenCalledWith(
-        "Bashの権限を要求しています",
-        "localhost", 50021, 1, 1.3, 5000, 3, 1000,
-      );
-    });
-
-    it("uses default message when no tool info", async () => {
-      const { runSpeak } = await import("./speak.js");
-      const payload = JSON.stringify({ hook_event_name: "PermissionRequest" });
-      await runSpeakHooks({ ...baseOptions, payload });
-      expect(runSpeak).toHaveBeenCalledWith(
-        "権限を要求しています",
-        "localhost", 50021, 1, 1.3, 5000, 3, 1000,
-      );
-    });
-  });
-
-  describe("SubagentStart", () => {
-    it("speaks subagent start with description", async () => {
-      const { runSpeak } = await import("./speak.js");
-      const payload = JSON.stringify({
-        hook_event_name: "SubagentStart",
-        agent_description: "ファイルを検索",
-      });
-      await runSpeakHooks({ ...baseOptions, payload });
-      expect(runSpeak).toHaveBeenCalledWith(
-        "サブエージェントを起動: ファイルを検索",
-        "localhost", 50021, 1, 1.3, 5000, 3, 1000,
-      );
-    });
-
-    it("speaks subagent start with agent type", async () => {
-      const { runSpeak } = await import("./speak.js");
-      const payload = JSON.stringify({
-        hook_event_name: "SubagentStart",
-        agent_type: "Explore",
-      });
-      await runSpeakHooks({ ...baseOptions, payload });
-      expect(runSpeak).toHaveBeenCalledWith(
-        "Exploreエージェントを起動します",
-        "localhost", 50021, 1, 1.3, 5000, 3, 1000,
-      );
-    });
-
-    it("uses default message when no info", async () => {
-      const { runSpeak } = await import("./speak.js");
-      const payload = JSON.stringify({ hook_event_name: "SubagentStart" });
-      await runSpeakHooks({ ...baseOptions, payload });
-      expect(runSpeak).toHaveBeenCalledWith(
-        "サブエージェントを起動します",
-        "localhost", 50021, 1, 1.3, 5000, 3, 1000,
-      );
-    });
-  });
-
   describe("TeammateIdle", () => {
     it("speaks teammate idle with name", async () => {
       const { runSpeak } = await import("./speak.js");
@@ -454,64 +391,26 @@ describe("runSpeakHooks", () => {
     });
   });
 
-  describe("ConfigChange", () => {
-    it("speaks config change with file", async () => {
+  describe("TaskCreated", () => {
+    it("speaks task creation with description", async () => {
       const { runSpeak } = await import("./speak.js");
       const payload = JSON.stringify({
-        hook_event_name: "ConfigChange",
-        config_file: "settings.json",
+        hook_event_name: "TaskCreated",
+        task_description: "コードレビュー",
       });
       await runSpeakHooks({ ...baseOptions, payload });
       expect(runSpeak).toHaveBeenCalledWith(
-        "設定を変更しました: settings.json",
+        "タスク作成: コードレビュー",
         "localhost", 50021, 1, 1.3, 5000, 3, 1000,
       );
     });
 
-    it("uses default message when no file", async () => {
+    it("uses default message when no description", async () => {
       const { runSpeak } = await import("./speak.js");
-      const payload = JSON.stringify({ hook_event_name: "ConfigChange" });
+      const payload = JSON.stringify({ hook_event_name: "TaskCreated" });
       await runSpeakHooks({ ...baseOptions, payload });
       expect(runSpeak).toHaveBeenCalledWith(
-        "設定を変更しました",
-        "localhost", 50021, 1, 1.3, 5000, 3, 1000,
-      );
-    });
-  });
-
-  describe("WorktreeCreate/WorktreeRemove", () => {
-    it("speaks worktree creation with name", async () => {
-      const { runSpeak } = await import("./speak.js");
-      const payload = JSON.stringify({
-        hook_event_name: "WorktreeCreate",
-        worktree_name: "feature-branch",
-      });
-      await runSpeakHooks({ ...baseOptions, payload });
-      expect(runSpeak).toHaveBeenCalledWith(
-        "ワークツリーを作成しました: feature-branch",
-        "localhost", 50021, 1, 1.3, 5000, 3, 1000,
-      );
-    });
-
-    it("speaks worktree removal with name", async () => {
-      const { runSpeak } = await import("./speak.js");
-      const payload = JSON.stringify({
-        hook_event_name: "WorktreeRemove",
-        worktree_name: "feature-branch",
-      });
-      await runSpeakHooks({ ...baseOptions, payload });
-      expect(runSpeak).toHaveBeenCalledWith(
-        "ワークツリーを削除しました: feature-branch",
-        "localhost", 50021, 1, 1.3, 5000, 3, 1000,
-      );
-    });
-
-    it("uses default message when no name", async () => {
-      const { runSpeak } = await import("./speak.js");
-      const payload = JSON.stringify({ hook_event_name: "WorktreeCreate" });
-      await runSpeakHooks({ ...baseOptions, payload });
-      expect(runSpeak).toHaveBeenCalledWith(
-        "ワークツリーを作成しました",
+        "タスクを作成しました",
         "localhost", 50021, 1, 1.3, 5000, 3, 1000,
       );
     });
@@ -524,6 +423,18 @@ describe("runSpeakHooks", () => {
       await runSpeakHooks({ ...baseOptions, payload });
       expect(runSpeak).toHaveBeenCalledWith(
         "コンテキストを圧縮します",
+        "localhost", 50021, 1, 1.3, 5000, 3, 1000,
+      );
+    });
+  });
+
+  describe("PostCompact", () => {
+    it("speaks post compact message", async () => {
+      const { runSpeak } = await import("./speak.js");
+      const payload = JSON.stringify({ hook_event_name: "PostCompact" });
+      await runSpeakHooks({ ...baseOptions, payload });
+      expect(runSpeak).toHaveBeenCalledWith(
+        "コンテキストの圧縮が完了しました",
         "localhost", 50021, 1, 1.3, 5000, 3, 1000,
       );
     });

--- a/src/commands/speak-hooks.ts
+++ b/src/commands/speak-hooks.ts
@@ -22,23 +22,15 @@ interface HookInput {
   tool_name?: string;
   tool_input?: Record<string, unknown>;
   tool_response?: unknown;
-  // PostToolUseFailure用（フィールド名は実際のペイロードで検証が必要）
+  // PostToolUseFailure fields
   error_message?: string;
-  // SubagentStart / SubagentStop fields (フィールド名は実際のペイロードで検証が必要)
+  // SubagentStart fields
   agent_type?: string;
   agent_description?: string;
-  // TaskCompleted fields (フィールド名は実際のペイロードで検証が必要)
+  // TaskCreated / TaskCompleted fields
   task_id?: string;
   task_description?: string;
-  // WorktreeCreate / WorktreeRemove fields (フィールド名は実際のペイロードで検証が必要)
-  worktree_path?: string;
-  worktree_name?: string;
-  // PermissionRequest fields (フィールド名は実際のペイロードで検証が必要)
-  permission_type?: string;
-  requested_tool?: string;
-  // ConfigChange fields (フィールド名は実際のペイロードで検証が必要)
-  config_file?: string;
-  // TeammateIdle fields (フィールド名は実際のペイロードで検証が必要)
+  // TeammateIdle fields
   teammate_name?: string;
 }
 
@@ -157,12 +149,6 @@ function getTextForHookEvent(eventName: string | undefined, hookData: HookInput,
       }
       return "ツールの実行に失敗しました";
 
-    case "PermissionRequest":
-      if (hookData.requested_tool) {
-        return `${hookData.requested_tool}の権限を要求しています`;
-      }
-      return "権限を要求しています";
-
     case "SubagentStart":
       if (hookData.agent_description) {
         return `サブエージェントを起動: ${firstLine(hookData.agent_description)}`;
@@ -178,32 +164,23 @@ function getTextForHookEvent(eventName: string | undefined, hookData: HookInput,
       }
       return "チームメイトが待機中です";
 
+    case "TaskCreated":
+      if (hookData.task_description) {
+        return `タスク作成: ${firstLine(hookData.task_description)}`;
+      }
+      return "タスクを作成しました";
+
     case "TaskCompleted":
       if (hookData.task_description) {
         return `タスク完了: ${firstLine(hookData.task_description)}`;
       }
       return "タスクが完了しました";
 
-    case "ConfigChange":
-      if (hookData.config_file) {
-        return `設定を変更しました: ${hookData.config_file}`;
-      }
-      return "設定を変更しました";
-
-    case "WorktreeCreate":
-      if (hookData.worktree_name) {
-        return `ワークツリーを作成しました: ${hookData.worktree_name}`;
-      }
-      return "ワークツリーを作成しました";
-
-    case "WorktreeRemove":
-      if (hookData.worktree_name) {
-        return `ワークツリーを削除しました: ${hookData.worktree_name}`;
-      }
-      return "ワークツリーを削除しました";
-
     case "PreCompact":
       return "コンテキストを圧縮します";
+
+    case "PostCompact":
+      return "コンテキストの圧縮が完了しました";
 
     default:
       return fallback;

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,28 +200,25 @@ program
   .description("Claude Code hooks に voicevox-cli speak-hooks を設定します")
   .option("--scope <scope>", "設定スコープ (project または user)", "project")
   .option("--events <events>", "カンマ区切りでイベントを指定 (例: Stop,SubagentStop,Notification)")
-  .option("--all", "全17イベントを設定する", false)
+  .option("--all", "全13イベントを設定する", false)
   .option("--dry-run", "設定をファイルに書き込まず出力のみ", false)
   .action(async (options) => {
     const defaultEvents = ["Stop", "SubagentStop", "Notification"];
+    // Claude Code v2.1.86 の settings.json バリデーションで受け入れられるイベント (13個)
     const allEvents = [
       "SessionStart",
       "SessionEnd",
       "UserPromptSubmit",
       "PreToolUse",
       "PostToolUse",
-      "PostToolUseFailure",
       "Notification",
-      "SubagentStart",
       "SubagentStop",
       "Stop",
-      "TeammateIdle",
-      "TaskCompleted",
-      "ConfigChange",
-      "WorktreeCreate",
-      "WorktreeRemove",
       "PreCompact",
-      "PermissionRequest",
+      "PostCompact",
+      "TeammateIdle",
+      "TaskCreated",
+      "TaskCompleted",
     ];
 
     let events: string[];


### PR DESCRIPTION
## Summary
- `setup-hooks --all` のイベントリストを Claude Code v2.1.86 の settings.json バリデーションで受け入れられる13イベントに修正
- バリデーションで拒否される6イベント（`ConfigChange`, `WorktreeCreate`, `WorktreeRemove`, `PostToolUseFailure`, `SubagentStart`, `PermissionRequest`）を `allEvents` から除外
- 新たにサポートされた `PostCompact`, `TaskCreated` イベントを追加
- `speak-hooks.ts` では内部イベント発火に備え `PostToolUseFailure` / `SubagentStart` のハンドリングは維持

## Test plan
- [x] `npm run build` がエラーなく完了する
- [x] `npm test` で全168テストがパスする
- [ ] `voicevox-cli setup-hooks --all --dry-run` で13イベントが出力されることを確認
- [ ] `voicevox-cli setup-hooks --dry-run` でデフォルト3イベント（Stop, SubagentStop, Notification）が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)